### PR TITLE
Add language params and other fixes

### DIFF
--- a/js/queryBuilders/buildAutocompleteQuery.js
+++ b/js/queryBuilders/buildAutocompleteQuery.js
@@ -11,6 +11,7 @@ function buildAutocompleteQueryParams() {
   setParamIfSpecified(params, 'boundary.rect.max_lon');
   setParamIfSpecified(params, 'focus.point.lat');
   setParamIfSpecified(params, 'focus.point.lon');
+  setParamIfSpecified(params, 'lang');
 
   return params;
 }

--- a/js/queryBuilders/buildPlaceQuery.js
+++ b/js/queryBuilders/buildPlaceQuery.js
@@ -2,6 +2,7 @@ function buildPlaceQueryParams() {
   var params = {};
 
   setParamIfSpecified(params, 'ids');
+  setParamIfSpecified(params, 'lang');
 
   return params;
 }

--- a/js/queryBuilders/buildReverseQuery.js
+++ b/js/queryBuilders/buildReverseQuery.js
@@ -7,6 +7,7 @@ function buildReverseQueryParams() {
   setParamIfSpecified(params, 'sources');
   setParamIfSpecified(params, 'layers');
   setParamIfSpecified(params, 'boundary.country');
+  setParamIfSpecified(params, 'lang');
 
   return params;
 }

--- a/js/queryBuilders/buildReverseQuery.js
+++ b/js/queryBuilders/buildReverseQuery.js
@@ -7,6 +7,7 @@ function buildReverseQueryParams() {
   setParamIfSpecified(params, 'sources');
   setParamIfSpecified(params, 'layers');
   setParamIfSpecified(params, 'boundary.country');
+  setParamIfSpecified(params, 'boundary.circle.radius');
   setParamIfSpecified(params, 'lang');
 
   return params;

--- a/js/queryBuilders/buildSearchQuery.js
+++ b/js/queryBuilders/buildSearchQuery.js
@@ -15,6 +15,7 @@ function buildSearchQueryParams() {
   setParamIfSpecified(params, 'boundary.circle.radius');
   setParamIfSpecified(params, 'focus.point.lat');
   setParamIfSpecified(params, 'focus.point.lon');
+  setParamIfSpecified(params, 'lang');
 
   return params;
 }

--- a/js/queryBuilders/buildStructuredQuery.js
+++ b/js/queryBuilders/buildStructuredQuery.js
@@ -24,6 +24,7 @@ function buildStructuredQueryParams() {
   setParamIfSpecified(params, 'boundary.circle.radius');
   setParamIfSpecified(params, 'focus.point.lat');
   setParamIfSpecified(params, 'focus.point.lon');
+  setParamIfSpecified(params, 'lang');
 
   return params;
 }

--- a/js/renderers/renderAutocompleteParams.js
+++ b/js/renderers/renderAutocompleteParams.js
@@ -24,7 +24,6 @@ function renderAutocompleteParams() {
   focusPoint.children[1].appendChild(createParam('focus.point.lon'));
   paramContainerEl.appendChild(focusPoint);
 
-
   /**
    * BOUNDARIES
    */
@@ -41,6 +40,13 @@ function renderAutocompleteParams() {
   boundaries.appendChild(boundaryCountry);
   boundaries.appendChild(boundaryRect);
   paramContainerEl.appendChild(boundaries);
+
+  /**
+   * LANGUAGE
+   */
+  var language = createExpandableGroup('language', true);
+  language.children[1].appendChild(createParam('lang', 7, 4));
+  paramContainerEl.appendChild(language);
 
   setFocus('text');
 }

--- a/js/renderers/renderPlaceParams.js
+++ b/js/renderers/renderPlaceParams.js
@@ -2,6 +2,13 @@ function renderPlaceParams() {
   var paramContainerEl = document.getElementById('params-form');
   paramContainerEl.appendChild(createParam('ids', 10, 1));
 
+  /**
+   * LANGUAGE
+   */
+  var language = createExpandableGroup('language', true);
+  language.children[1].appendChild(createParam('lang', 7, 4));
+  paramContainerEl.appendChild(language);
+
   setFocus('ids');
 }
 

--- a/js/renderers/renderReverseParams.js
+++ b/js/renderers/renderReverseParams.js
@@ -23,8 +23,12 @@ function renderReverseParams() {
   var boundaryCountry = createExpandableGroup('boundary.country', true);
   boundaryCountry.children[1].appendChild(createParam('boundary.country'));
 
+  var boundaryCircle = createExpandableGroup('boundary.circle', true);
+  boundaryCircle.children[1].appendChild(createParam('boundary.circle.radius'));
+
   var boundaries = createExpandableGroup('boundary', false);
   boundaries.appendChild(boundaryCountry);
+  boundaries.appendChild(boundaryCircle);
   paramContainerEl.appendChild(boundaries);
 
   /**

--- a/js/renderers/renderReverseParams.js
+++ b/js/renderers/renderReverseParams.js
@@ -34,6 +34,13 @@ function renderReverseParams() {
   size.children[1].appendChild(createParam('size', 7, 4));
   paramContainerEl.appendChild(size);
 
+  /**
+   * LANGUAGE
+   */
+  var language = createExpandableGroup('language', true);
+  language.children[1].appendChild(createParam('lang', 7, 4));
+  paramContainerEl.appendChild(language);
+
   setFocus('point.lat');
 }
 

--- a/js/renderers/renderSearchParams.js
+++ b/js/renderers/renderSearchParams.js
@@ -56,6 +56,13 @@ function renderSearchParams() {
   size.children[1].appendChild(createParam('size', 7, 4));
   paramContainerEl.appendChild(size);
 
+  /**
+   * LANGUAGE
+   */
+  var language = createExpandableGroup('language', true);
+  language.children[1].appendChild(createParam('lang', 7, 4));
+  paramContainerEl.appendChild(language);
+
   setFocus('text');
 }
 
@@ -76,4 +83,5 @@ function loadSearchParams(params) {
   setInputFieldIfSpecified(params, 'boundary.circle.lat');
   setInputFieldIfSpecified(params, 'boundary.circle.lon');
   setInputFieldIfSpecified(params, 'boundary.circle.radius');
+  setInputFieldIfSpecified(params, 'lang');
 }

--- a/js/renderers/renderStructuredParams.js
+++ b/js/renderers/renderStructuredParams.js
@@ -66,6 +66,13 @@ function renderStructuredParams() {
   size.children[1].appendChild(createParam('size', 7, 4));
   paramContainerEl.appendChild(size);
 
+  /**
+   * LANGUAGE
+   */
+  var language = createExpandableGroup('language', true);
+  language.children[1].appendChild(createParam('lang', 7, 4));
+  paramContainerEl.appendChild(language);
+
   setFocus('address');
 }
 

--- a/js/utilities/mapzen-services.js
+++ b/js/utilities/mapzen-services.js
@@ -24,7 +24,7 @@ function buildUrl(query, params, display) {
   params = params || {};
 
   if (display) {
-    params.api_key = 'YOUR_KEY';
+    params.api_key = 'your-mapzen-api-key';
   }
   else {
     params.api_key = search_api_key;


### PR DESCRIPTION
Fixes #1 
Fixes #2 

- Adds language parameters to all the endpoints, even though they don't all return results (see https://github.com/pelias/pelias/issues/604). I think it's OK to go ahead and add these to the UI, rather than try to comment them out until the service is updated.
- Adds boundary.circle.radius to reverse.
- Changes the placeholder API key shown in the sample query to `your-mapzen-api-key`. This string is being used (eventually) in documentation to replace placeholder API keys with real ones when a user is signed in on mapzen.com.